### PR TITLE
fix(origin-ui-core): fixed opening organization details always

### DIFF
--- a/packages/origin-ui-core/src/components/Organization/OrganizationView.tsx
+++ b/packages/origin-ui-core/src/components/Organization/OrganizationView.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
+import { useParams } from 'react-router-dom';
 import { makeStyles, createStyles, useTheme, Paper, Grid, TextField } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
 import { Countries } from '@energyweb/utils-general';
 import { getUserOffchain } from '../../features/users/selectors';
+import { getOffChainDataSource } from '../../features/general/selectors';
 
 interface IFormValues {
     code: string;
@@ -30,9 +32,10 @@ interface IFormValues {
 
 export function OrganizationView() {
     const userOffchain = useSelector(getUserOffchain);
-
+    const organizationClient = useSelector(getOffChainDataSource)?.organizationClient;
+    const params = useParams()
     const [formValues, setFormValues] = useState<IFormValues>(null);
-
+    
     const useStyles = makeStyles(() =>
         createStyles({
             container: {
@@ -43,22 +46,38 @@ export function OrganizationView() {
 
     const classes = useStyles(useTheme());
 
+    const setValues = (organization, activeCountriesParsed) => {
+        setFormValues({
+            ...organization,
+            headquartersCountry: Countries.find(
+                (c) => c.id === organization.headquartersCountry
+            ).name,
+            activeCountries: Countries.filter((c) => activeCountriesParsed.includes(c.id))
+                .map((country) => country.name)
+                .join(', '),
+            country: Countries.find((c) => c.id === organization.country).name
+    });
+    }
+
     useEffect(() => {
-        const organization = userOffchain?.organization;
-        if (organization) {
-            const activeCountriesParsed: number[] = JSON.parse(organization.activeCountries);
-            setFormValues({
-                ...organization,
-                headquartersCountry: Countries.find(
-                    (c) => c.id === organization.headquartersCountry
-                ).name,
-                activeCountries: Countries.filter((c) => activeCountriesParsed.includes(c.id))
-                    .map((country) => country.name)
-                    .join(', '),
-                country: Countries.find((c) => c.id === organization.country).name
-            });
-        }
-    }, [userOffchain]);
+
+        if (!params.id) {
+            const organization = userOffchain?.organization;
+            if (organization) {
+                const activeCountriesParsed: number[] = JSON.parse(organization.activeCountries);
+                setValues(organization, activeCountriesParsed)
+            }
+        } else {     
+            const getOrganization = async () => {
+                const organization = await organizationClient.getById(parseInt(params.id));     
+                if (organization) {
+                        const activeCountriesParsed: number[] = JSON.parse(organization.activeCountries);
+                        setValues(organization, activeCountriesParsed)
+                }
+            }
+        getOrganization()
+    }
+    }, [params]);
 
     if (!formValues) {
         return <Skeleton variant="rect" height={200} />;


### PR DESCRIPTION
Fixed issue when opening organization details always showed the same organization in the following scenario:
1. Log in as an admin
2. Navigate to all organizations
3. Whichever one you click it will always show "Trader Organization"

